### PR TITLE
58 open channels cannot be created from raven dashboard

### DIFF
--- a/raven-app/src/components/feature/channel-details/ChannelDetails.tsx
+++ b/raven-app/src/components/feature/channel-details/ChannelDetails.tsx
@@ -1,6 +1,6 @@
 import { Box, HStack, Stack, useColorMode, Text, Button, Divider, useDisclosure } from "@chakra-ui/react"
 import { useContext } from "react"
-import { BiHash, BiLockAlt } from "react-icons/bi"
+import { BiGlobe, BiHash, BiLockAlt } from "react-icons/bi"
 import { UserContext } from "../../../utils/auth/UserProvider"
 import { ChannelContext } from "../../../utils/channel/ChannelProvider"
 import { DateObjectToFormattedDateString } from "../../../utils/operations"
@@ -33,7 +33,9 @@ export const ChannelDetails = () => {
                     <Stack>
                         <Text fontWeight='semibold' fontSize='sm'>Channel name</Text>
                         <HStack spacing={1}>
-                            {channelData[0].type === 'Private' ? <BiLockAlt /> : <BiHash />}
+                            {channelData[0].type === 'Private' && <BiLockAlt /> ||
+                                channelData[0].type === 'Public' && <BiHash /> ||
+                                channelData[0].type === 'Open' && <BiGlobe />}
                             <Text fontSize='sm'>{channelData[0].channel_name}</Text>
                         </HStack>
                     </Stack>

--- a/raven-app/src/components/feature/channel-details/EditChannelDetails/ChannelRenameModal.tsx
+++ b/raven-app/src/components/feature/channel-details/EditChannelDetails/ChannelRenameModal.tsx
@@ -1,8 +1,8 @@
-import { Button, ButtonGroup, chakra, FormControl, FormErrorMessage, FormHelperText, FormLabel, Input, InputGroup, InputLeftElement, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Stack, useToast } from "@chakra-ui/react"
+import { Text, Button, ButtonGroup, chakra, FormControl, FormErrorMessage, FormHelperText, FormLabel, Input, InputGroup, InputLeftElement, InputRightElement, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Stack, useToast } from "@chakra-ui/react"
 import { useFrappeUpdateDoc } from "frappe-react-sdk"
 import { useContext, useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
-import { BiHash, BiLockAlt } from "react-icons/bi"
+import { BiGlobe, BiHash, BiLockAlt } from "react-icons/bi"
 import { ChannelContext } from "../../../../utils/channel/ChannelProvider"
 import { AlertBanner } from "../../../layout/AlertBanner"
 
@@ -23,9 +23,10 @@ export const ChannelRenameModal = ({ isOpen, onClose }: RenameChannelModalProps)
             channel_name: channelData[0]?.channel_name
         }
     })
-    const { register, handleSubmit, reset, formState: { errors } } = methods
+    const { register, handleSubmit, reset, watch, formState: { errors } } = methods
     const { updateDoc, loading: updatingDoc, error, reset: resetUpdate } = useFrappeUpdateDoc()
     const toast = useToast()
+    const channel_name = watch('channel_name')
 
     useEffect(() => {
         reset()
@@ -82,11 +83,28 @@ export const ChannelRenameModal = ({ isOpen, onClose }: RenameChannelModalProps)
                                         <InputGroup fontSize='sm'>
                                             <InputLeftElement
                                                 pointerEvents='none'
-                                                children={channelData[0].type === 'Private' ? <BiLockAlt /> : <BiHash />} />
-                                            <Input {...register('channel_name', { required: "Please add a new channel name", maxLength: 80 })} />
+                                                children={channelData[0].type === 'Private' && <BiLockAlt /> ||
+                                                    channelData[0].type === 'Public' && <BiHash /> ||
+                                                    channelData[0].type === 'Open' && <BiGlobe />} />
+                                            {/* <Input {...register('channel_name', { required: "Please add a new channel name", maxLength: 80 })} /> */}
+                                            <Input
+                                                maxLength={50}
+                                                autoFocus {...register('channel_name', {
+                                                    required: "Please add channel name",
+                                                    maxLength: 50,
+                                                    pattern: {
+                                                        // no special characters allowed
+                                                        // cannot start with a space
+                                                        value: /^[a-zA-Z0-9][a-zA-Z0-9 ]*$/,
+                                                        message: "Channel name can only contain letters and numbers"
+                                                    }
+                                                })} />
+                                            <InputRightElement>
+                                                <Text fontSize='sm' fontWeight='light' color='gray.500'>{50 - channel_name?.length}</Text>
+                                            </InputRightElement>
                                         </InputGroup>
                                     </Stack>
-                                    <FormHelperText fontSize='xs'>Names cannot be longer than 80 characters.</FormHelperText>
+                                    <FormHelperText fontSize='xs'>Names cannot be longer than 50 characters.</FormHelperText>
                                     <FormErrorMessage>{errors?.channel_name?.message}</FormErrorMessage>
                                 </FormControl>
 

--- a/raven-app/src/components/feature/channels/ChannelList.tsx
+++ b/raven-app/src/components/feature/channels/ChannelList.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure } from "@chakra-ui/react"
 import { useFrappeGetCall } from "frappe-react-sdk"
-import { BiHash } from "react-icons/bi"
+import { BiGlobe, BiHash } from "react-icons/bi"
 import { BiLockAlt } from "react-icons/bi"
 import { IoAdd } from "react-icons/io5"
 import { ChannelData } from "../../../types/Channel/Channel"
@@ -12,7 +12,7 @@ import { CreateChannelModal } from "./CreateChannelModal"
 export const ChannelList = () => {
 
     const { data, error, mutate } = useFrappeGetCall<{ message: ChannelData[] }>("raven.raven_channel_management.doctype.raven_channel.raven_channel.get_channel_list")
-    
+
     const handleClose = (refresh?: boolean) => {
         if (refresh) {
             mutate()
@@ -31,22 +31,22 @@ export const ChannelList = () => {
     return (
         <>
             <SidebarGroup>
-            <SidebarGroupItem>
-                <SidebarGroupLabel>Channels</SidebarGroupLabel>
-            </SidebarGroupItem>
-            <SidebarGroupList>
-                {data?.message.filter((channel) => channel.is_direct_message === 0).map((channel) => (
-                    <SidebarItem to={channel.name} key={channel.name}>
-                        <SidebarIcon>{channel.type === "Private" ? <BiLockAlt /> : <BiHash />}</SidebarIcon>
-                        <SidebarItemLabel>{channel.channel_name}</SidebarItemLabel>
-                    </SidebarItem>
-                ))}
-                 <SidebarButtonItem key={'create-channel'} onClick={onOpen}>
+                <SidebarGroupItem>
+                    <SidebarGroupLabel>Channels</SidebarGroupLabel>
+                </SidebarGroupItem>
+                <SidebarGroupList>
+                    {data?.message.filter((channel) => channel.is_direct_message === 0).map((channel) => (
+                        <SidebarItem to={channel.name} key={channel.name}>
+                            <SidebarIcon>{channel.type === "Private" && <BiLockAlt /> || channel.type === "Public" && <BiHash /> || channel.type === "Open" && <BiGlobe />}</SidebarIcon>
+                            <SidebarItemLabel>{channel.channel_name}</SidebarItemLabel>
+                        </SidebarItem>
+                    ))}
+                    <SidebarButtonItem key={'create-channel'} onClick={onOpen}>
                         <SidebarIcon><IoAdd /></SidebarIcon>
                         <SidebarItemLabel>Add channel</SidebarItemLabel>
                     </SidebarButtonItem>
-            </SidebarGroupList>
-        </SidebarGroup>
+                </SidebarGroupList>
+            </SidebarGroup>
             <CreateChannelModal isOpen={isOpen} onClose={handleClose} />
         </>
     )

--- a/raven-app/src/components/feature/channels/CreateChannelModal.tsx
+++ b/raven-app/src/components/feature/channels/CreateChannelModal.tsx
@@ -2,8 +2,7 @@ import { Button, ButtonGroup, chakra, FormControl, FormErrorMessage, FormHelperT
 import { useFrappeCreateDoc } from 'frappe-react-sdk'
 import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
-import { BiHash, BiLockAlt } from 'react-icons/bi'
-import { HiSpeakerWave } from 'react-icons/hi2'
+import { BiGlobe, BiHash, BiLockAlt } from 'react-icons/bi'
 import { useNavigate } from 'react-router-dom'
 import { AlertBanner } from '../../layout/AlertBanner'
 
@@ -107,7 +106,7 @@ export const CreateChannelModal = ({ isOpen, onClose }: ChannelModalProps) => {
                                         <InputGroup>
                                             <InputLeftElement
                                                 pointerEvents='none'
-                                                children={channelType === 'Private' && <BiLockAlt /> || channelType === 'Open' && <HiSpeakerWave /> || channelType === 'Public' && <BiHash />}
+                                                children={channelType === 'Private' && <BiLockAlt /> || channelType === 'Open' && <BiGlobe /> || channelType === 'Public' && <BiHash />}
                                             />
                                             <Input
                                                 maxLength={50}

--- a/raven-app/src/components/feature/channels/CreateChannelModal.tsx
+++ b/raven-app/src/components/feature/channels/CreateChannelModal.tsx
@@ -1,8 +1,9 @@
-import { Button, ButtonGroup, chakra, FormControl, FormErrorMessage, FormHelperText, FormLabel, HStack, Input, InputGroup, InputLeftElement, InputRightElement, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Stack, Switch, Text, useToast } from '@chakra-ui/react'
+import { Button, ButtonGroup, chakra, FormControl, FormErrorMessage, FormHelperText, FormLabel, HStack, Input, InputGroup, InputLeftElement, InputRightElement, Modal, ModalBody, ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalOverlay, Radio, RadioGroup, Stack, Switch, Text, useToast } from '@chakra-ui/react'
 import { useFrappeCreateDoc } from 'frappe-react-sdk'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { BiHash, BiLockAlt } from 'react-icons/bi'
+import { HiSpeakerWave } from 'react-icons/hi2'
 import { useNavigate } from 'react-router-dom'
 import { AlertBanner } from '../../layout/AlertBanner'
 
@@ -14,7 +15,7 @@ interface ChannelModalProps {
 interface ChannelCreationForm {
     channel_name: string,
     channel_description: string
-    type: 'Public' | 'Private'
+    type: 'Public' | 'Private' | 'Open'
 }
 
 export const CreateChannelModal = ({ isOpen, onClose }: ChannelModalProps) => {
@@ -36,7 +37,7 @@ export const CreateChannelModal = ({ isOpen, onClose }: ChannelModalProps) => {
 
     const channelType = watch('type')
     const channel_name = watch('channel_name')
-    
+
     let navigate = useNavigate()
 
     const onSubmit = (data: ChannelCreationForm) => {
@@ -70,15 +71,21 @@ export const CreateChannelModal = ({ isOpen, onClose }: ChannelModalProps) => {
         onClose()
     }
 
-    const onChannelTypeToggle = () => {
-        methods.setValue('type', channelType === 'Private' ? 'Public' : 'Private')
+    const [channelTypeValue, setChannelTypeValue] = useState<'Public' | 'Private' | 'Open'>('Public')
+    const setChannelType = (value: 'Public' | 'Private' | 'Open') => {
+        setChannelTypeValue(value)
+        methods.setValue('type', value)
     }
 
     return (
         <Modal isOpen={isOpen} onClose={onClose} size='lg'>
             <ModalOverlay />
             <ModalContent>
-                <ModalHeader fontSize='2xl'>{channelType === 'Private' ? "Create a private channel" : "Create a channel"}</ModalHeader>
+                <ModalHeader fontSize='2xl'>
+                    {channelType === 'Private' && "Create a private channel"}
+                    {channelType === 'Open' && "Create an open channel"}
+                    {channelType === 'Public' && "Create a public channel"}
+                </ModalHeader>
                 <ModalCloseButton isDisabled={creatingDoc} />
 
                 <FormProvider {...methods}>
@@ -100,20 +107,20 @@ export const CreateChannelModal = ({ isOpen, onClose }: ChannelModalProps) => {
                                         <InputGroup>
                                             <InputLeftElement
                                                 pointerEvents='none'
-                                                children={channelType === 'Private' ? <BiLockAlt /> : <BiHash />}
+                                                children={channelType === 'Private' && <BiLockAlt /> || channelType === 'Open' && <HiSpeakerWave /> || channelType === 'Public' && <BiHash />}
                                             />
-                                            <Input 
-                                            maxLength={50}
-                                            autoFocus {...register('channel_name', { 
-                                                required: "Please add channel name", 
-                                                maxLength: 50,
-                                                pattern: {
-                                                    // no special characters allowed
-                                                    // cannot start with a space
-                                                    value: /^[a-zA-Z0-9][a-zA-Z0-9 ]*$/,
-                                                    message: "Channel name can only contain letters and numbers"
-                                                }
-                                             })}
+                                            <Input
+                                                maxLength={50}
+                                                autoFocus {...register('channel_name', {
+                                                    required: "Please add channel name",
+                                                    maxLength: 50,
+                                                    pattern: {
+                                                        // no special characters allowed
+                                                        // cannot start with a space
+                                                        value: /^[a-zA-Z0-9][a-zA-Z0-9 ]*$/,
+                                                        message: "Channel name can only contain letters and numbers"
+                                                    }
+                                                })}
                                                 placeholder='e.g. testing' fontSize='sm' />
                                             <InputRightElement>
                                                 <Text fontSize='sm' fontWeight='light' color='gray.500'>{50 - channel_name?.length}</Text>
@@ -135,24 +142,35 @@ export const CreateChannelModal = ({ isOpen, onClose }: ChannelModalProps) => {
                                     </FormControl>
 
                                     <FormControl>
-                                        <HStack spacing={8} alignItems='center'>
-                                            <Stack>
-                                                <FormLabel htmlFor='email-alerts' mb='0'>
-                                                    Make private?
-                                                </FormLabel>
-                                                {channelType === 'Private'
-                                                    ?
-                                                    <Text fontSize='sm' fontWeight='light'>
-                                                        <strong>This cannot be undone.</strong> A private channel cannot be made public later on.
-                                                    </Text>
-                                                    :
-                                                    <Text fontSize='sm' fontWeight='light'>
-                                                        When a channel is set to private, it can only be viewed or joined by invitation.
-                                                    </Text>
-                                                }
-                                            </Stack>
-                                            <Switch id='type' pt='4' checked={channelType === 'Private'} onChange={onChannelTypeToggle} />
-                                        </HStack>
+                                        <Stack>
+                                            <FormLabel htmlFor='email-alerts' mb='0'>
+                                                Channel Type
+                                            </FormLabel>
+                                            <RadioGroup id='type' onChange={setChannelType} value={channelTypeValue}>
+                                                <Stack direction='row'>
+                                                    <Radio value='Public'>Public</Radio>
+                                                    <Radio value='Private'>Private</Radio>
+                                                    <Radio value='Open'>Open</Radio>
+                                                </Stack>
+                                            </RadioGroup>
+                                            {channelType === 'Private' &&
+                                                <Text fontSize='xs' fontWeight='light'>
+                                                    <strong>This cannot be undone.</strong>
+                                                    When a channel is set to private, it can only be viewed or joined by invitation.
+                                                    A private channel cannot be made public later on.
+                                                </Text>
+                                            }
+                                            {channelType === 'Public' &&
+                                                <Text fontSize='xs' fontWeight='light'>
+                                                    When a channel is set to public, anyone can join the channel and read messages, but only members can post messages.
+                                                </Text>
+                                            }
+                                            {channelType === 'Open' &&
+                                                <Text fontSize='xs' fontWeight='light'>
+                                                    When a channel is set to open, everyone is a member.
+                                                </Text>
+                                            }
+                                        </Stack>
                                     </FormControl>
                                 </Stack>
                             </Stack>

--- a/raven-app/src/components/feature/channels/ViewChannelDetailsModal.tsx
+++ b/raven-app/src/components/feature/channels/ViewChannelDetailsModal.tsx
@@ -1,6 +1,6 @@
 import { Text, Modal, ModalBody, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay, HStack, Tabs, TabList, Tab, TabPanels, TabPanel } from "@chakra-ui/react"
 import { useContext } from "react"
-import { BiHash, BiLockAlt } from "react-icons/bi"
+import { BiGlobe, BiHash, BiLockAlt } from "react-icons/bi"
 import { ChannelContext } from "../../../utils/channel/ChannelProvider"
 import { ChannelDetails } from "../channel-details/ChannelDetails"
 import { ChannelMemberDetails } from "../channel-details/ChannelMemberDetails"
@@ -22,11 +22,9 @@ export const ViewChannelDetailsModal = ({ isOpen, onClose }: ViewChannelDetailsM
             <ModalContent>
 
                 <ModalHeader>
-                    {channelData[0].type === 'Public'
-                        ?
-                        <HStack><BiHash /><Text>{channelData[0].channel_name}</Text></HStack>
-                        :
-                        <HStack><BiLockAlt /><Text>{channelData[0].channel_name}</Text></HStack>
+                    {channelData[0].type === 'Public' && <HStack><BiHash /><Text>{channelData[0].channel_name}</Text></HStack> ||
+                        channelData[0].type === 'Private' && <HStack><BiLockAlt /><Text>{channelData[0].channel_name}</Text></HStack> ||
+                        channelData[0].type === 'Open' && <HStack><BiGlobe /><Text>{channelData[0].channel_name}</Text></HStack>
                     }
                 </ModalHeader>
                 <ModalCloseButton mt='2' />

--- a/raven-app/src/components/feature/chat/ChatInterface.tsx
+++ b/raven-app/src/components/feature/chat/ChatInterface.tsx
@@ -1,7 +1,7 @@
 import { Avatar, AvatarBadge, Box, Button, HStack, Stack, Text, useColorMode, useDisclosure, useToast } from "@chakra-ui/react"
 import { useFrappeCreateDoc, useFrappeGetCall, useFrappeGetDocList } from "frappe-react-sdk"
 import { useContext } from "react"
-import { BiHash, BiLockAlt } from "react-icons/bi"
+import { BiGlobe, BiHash, BiLockAlt } from "react-icons/bi"
 import { useFrappeEventListener } from "../../../hooks/useFrappeEventListener"
 import { ChannelData } from "../../../types/Channel/Channel"
 import { ChannelContext } from "../../../utils/channel/ChannelProvider"
@@ -119,9 +119,13 @@ export const ChatInterface = () => {
                                         </Avatar>
                                         <Text>{channelMembers?.[user]?.full_name}</Text><Text fontSize='sm' color='gray.500'>(You)</Text>
                                     </HStack>) :
-                                (channelData[0]?.type === 'Private' ?
-                                    <HStack><BiLockAlt /><Text>{channelData[0]?.channel_name}</Text></HStack> :
-                                    <HStack><BiHash /><Text>{channelData[0]?.channel_name}</Text></HStack>)}
+                                (channelData[0]?.type === 'Private' &&
+                                    <HStack><BiLockAlt /><Text>{channelData[0]?.channel_name}</Text></HStack> ||
+                                    channelData[0]?.type === 'Public' &&
+                                    <HStack><BiHash /><Text>{channelData[0]?.channel_name}</Text></HStack> ||
+                                    channelData[0]?.type === 'Open' &&
+                                    <HStack><BiGlobe /><Text>{channelData[0]?.channel_name}</Text></HStack>
+                                )}
                         </HStack>
                     </PageHeading>
                 }

--- a/raven-app/src/components/feature/view-or-add-members/ViewOrAddMembersButton.tsx
+++ b/raven-app/src/components/feature/view-or-add-members/ViewOrAddMembersButton.tsx
@@ -10,7 +10,7 @@ interface ViewOrAddMembersButtonProps {
 
 export const ViewOrAddMembersButton = ({ onClickViewMembers, onClickAddMembers }: ViewOrAddMembersButtonProps) => {
 
-    const { channelMembers } = useContext(ChannelContext)
+    const { channelData, channelMembers } = useContext(ChannelContext)
     const members = Object.values(channelMembers)
 
     return (
@@ -22,11 +22,13 @@ export const ViewOrAddMembersButton = ({ onClickViewMembers, onClickAddMembers }
                     ))}
                 </AvatarGroup>
             </Button>
-            <IconButton
-                onClick={onClickAddMembers}
-                aria-label={"add members to channel"}
-                icon={<RiUserAddLine />}
-            />
+            {(channelData[0].type === 'Private' || channelData[0].type === 'Public') &&
+                <IconButton
+                    onClick={onClickAddMembers}
+                    aria-label={"add members to channel"}
+                    icon={<RiUserAddLine />}
+                />
+            }
         </ButtonGroup>
     )
 }


### PR DESCRIPTION
- changed create channel modal to handle open channel creation
- added open channel in sidebar
- updated chat header to handle open channels
- updated view channel details modal for open channel
- fix: channel rename modal, channel length - 50, no special characters, cannot be empty
- removed add members button for open channels

this closes issue #57