### PR TITLE
63 add support for file messages

### DIFF
--- a/raven-app/src/components/feature/chat/ChatHistory.tsx
+++ b/raven-app/src/components/feature/chat/ChatHistory.tsx
@@ -28,7 +28,7 @@ export const ChatHistory = ({ messages }: ChatHistoryProps) => {
                     return <ChatMessage
                         key={message.name}
                         name={message.name}
-                        image={message.image}
+                        image={message.file}
                         user={message.owner}
                         timestamp={new Date(message.creation)} />
                 }

--- a/raven-app/src/components/feature/chat/ChatInput.tsx
+++ b/raven-app/src/components/feature/chat/ChatInput.tsx
@@ -14,12 +14,15 @@ import { IoMdAdd } from 'react-icons/io'
 import { VscMention } from 'react-icons/vsc'
 import { CustomFile, FileDrop } from "../file-upload/FileDrop"
 import { FileListItem } from "../file-upload/FileListItem"
+import { getFileExtension } from "../../../utils/operations"
 
 interface ChatInputProps {
     channelID: string,
     allMembers: { id: string; value: string; }[],
     allChannels: { id: string; value: string; }[]
 }
+
+export const fileExt = ['jpg', 'JPG', 'jpeg', 'JPEG', 'png', 'PNG', 'gif', 'GIF']
 
 export const ChatInput = ({ channelID, allMembers, allChannels }: ChatInputProps) => {
 
@@ -57,7 +60,6 @@ export const ChatInput = ({ channelID, allMembers, allChannels }: ChatInputProps
             })
         }
         if (files.length > 0) {
-            console.log(files)
             const promises = files.map(async (f: CustomFile) => {
                 let docname = ''
                 return createDoc('Raven Message', {
@@ -73,7 +75,7 @@ export const ChatInput = ({ channelID, allMembers, allChannels }: ChatInputProps
                 }).then((r) => {
                     return updateDoc("Raven Message", docname, {
                         file: r.file_url,
-                        message_type: r.file_url.split('.')[-1] in ['jpg', 'JPG', 'jpeg', 'JPEG', 'png', 'PNG', 'gif', 'GIF'] ? 'Image' : 'File'
+                        message_type: fileExt.includes(getFileExtension(f.name)) ? "Image" : "File",
                     })
                 })
             })
@@ -212,7 +214,7 @@ export const ChatInput = ({ channelID, allMembers, allChannels }: ChatInputProps
                                 onClick={onMentionIconClick} />
                         </HStack>
                         <IconButton
-                            isDisabled={text.length === 0}
+                            isDisabled={text.length === 0 && files.length === 0}
                             colorScheme='blue'
                             onClick={onSubmit}
                             mx='4'

--- a/raven-app/src/components/feature/chat/ChatInterface.tsx
+++ b/raven-app/src/components/feature/chat/ChatInterface.tsx
@@ -25,7 +25,7 @@ export const ChatInterface = () => {
     const peer = Object.keys(channelMembers).filter((member) => member !== user)[0]
     const { data: channelList, error: channelListError } = useFrappeGetCall<{ message: ChannelData[] }>("raven.raven_channel_management.doctype.raven_channel.raven_channel.get_channel_list")
     const { data, error, mutate } = useFrappeGetDocList<Message>('Raven Message', {
-        fields: ["text", "creation", "name", "owner", "message_type", "file", "image"],
+        fields: ["text", "creation", "name", "owner", "message_type", "file"],
         filters: [["channel_id", "=", channelData[0].name ?? null]],
         orderBy: {
             field: "creation",

--- a/raven-app/src/components/feature/file-upload/FileListItem.tsx
+++ b/raven-app/src/components/feature/file-upload/FileListItem.tsx
@@ -2,6 +2,7 @@ import { ListItem, Text, Stack, IconButton, HStack, ListIcon, ListItemProps, Ima
 import { TbTrash } from 'react-icons/tb'
 import { useGetFilePreviewUrl } from '../../../hooks/useGetFilePreviewUrl'
 import { getFileExtensionIcon } from '../../../utils/layout/fileExtensionIcon'
+import { getFileExtension } from '../../../utils/operations'
 import { CustomFile } from './FileDrop'
 
 interface FileListItemProps extends ListItemProps {
@@ -21,7 +22,7 @@ export const FileListItem = ({ file, removeFile, isUploading, uploadProgress, ..
         <ListItem fontSize="sm" {...props}>
             <HStack w='full' justify={'flex-start'} border={'1px'} borderColor={colorMode === 'light' ? 'gray.300' : 'gray.600'} p='2' rounded='md'>
                 <Center maxW='50px'>
-                    {previewURL ? <Image src={previewURL} alt='File preview' boxSize={'30px'} rounded='md' /> : <ListIcon as={getFileExtensionIcon(getFileExtension(file) ?? '')} boxSize="6" />}
+                    {previewURL ? <Image src={previewURL} alt='File preview' boxSize={'30px'} rounded='md' /> : <ListIcon as={getFileExtensionIcon(getFileExtension(file.name) ?? '')} boxSize="6" />}
                 </Center>
                 <HStack justify="space-between" width="calc(100% - 50px)">
                     <Stack spacing={0} w='full' whiteSpace="nowrap" overflow="hidden">
@@ -52,8 +53,4 @@ export const FileListItem = ({ file, removeFile, isUploading, uploadProgress, ..
 
 export const getFileSize = (file: CustomFile) => {
     return file.size / 1000 > 1000 ? <>{(file.size / 1000000).toFixed(2)} MB</> : <>{(file.size / 1000).toFixed(2)} KB</>
-}
-
-export const getFileExtension = (file: CustomFile) => {
-    return file.name.split('.').pop()
 }

--- a/raven-app/src/components/feature/file-upload/FileListItem.tsx
+++ b/raven-app/src/components/feature/file-upload/FileListItem.tsx
@@ -33,7 +33,7 @@ export const FileListItem = ({ file, removeFile, isUploading, uploadProgress, ..
                     </Stack>
                     {isUploading
                         ?
-                        <CircularProgress size='40px' thickness='8px' color='green.500' value={uploadProgress}>
+                        <CircularProgress size='30px' thickness='6px' color='green.500' value={uploadProgress}>
                             <CircularProgressLabel>{uploadProgress}%</CircularProgressLabel>
                         </CircularProgress>
                         :

--- a/raven-app/src/types/Messaging/Message.ts
+++ b/raven-app/src/types/Messaging/Message.ts
@@ -1,6 +1,5 @@
 export type Message = {
     text: string,
-    image: string,
     file: string,
     message_type: string,
     creation: Date,

--- a/raven-app/src/utils/operations.ts
+++ b/raven-app/src/utils/operations.ts
@@ -31,3 +31,14 @@ export const DateObjectToTimeString = (date: Date): string => {
     var date = new Date(date)
     return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true })
 }
+
+/**
+ * Function to return extension of a file
+ * @param filename name of the file with extension
+ * @returns extension
+ */
+export const getFileExtension = (filename: string) => {
+
+    const extension = filename.substring(filename.lastIndexOf('.') + 1, filename.length);
+    return extension;
+}

--- a/raven/raven_messaging/doctype/raven_message/raven_message.json
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.json
@@ -10,7 +10,6 @@
  "field_order": [
   "channel_id",
   "text",
-  "image",
   "file",
   "message_type"
  ],
@@ -29,11 +28,6 @@
    "label": "Text"
   },
   {
-   "fieldname": "image",
-   "fieldtype": "Attach Image",
-   "label": "Image"
-  },
-  {
    "fieldname": "file",
    "fieldtype": "Attach",
    "label": "File"
@@ -47,7 +41,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-04 21:07:18.620929",
+ "modified": "2023-03-05 08:00:05.858737",
  "modified_by": "Administrator",
  "module": "Raven Messaging",
  "name": "Raven Message",
@@ -80,8 +74,13 @@
    "write": 1
   },
   {
+   "email": 1,
+   "export": 1,
+   "print": 1,
    "read": 1,
-   "role": "Raven User"
+   "report": 1,
+   "role": "Raven User",
+   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/raven/raven_messaging/doctype/raven_message/raven_message.py
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.py
@@ -29,7 +29,8 @@ def send_message(channel_id, text):
     doc = frappe.get_doc({
         'doctype': 'Raven Message',
         'channel_id': channel_id,
-        'text': text
+        'text': text,
+        'message_type': 'Text'
     })
     doc.insert()
     frappe.publish_realtime('message_received', {


### PR DESCRIPTION
users can upload files such as images (jpg, png, jpeg) and files (csv, xlsx, docx)
1. file messages are saved with file type (text, image or file)
2. file messages are saved in the DB, with upload progress and success, error states shown on the UI
3. file messages if of type image can be previewed/ downloaded and if of type file, can be downloaded from the UI